### PR TITLE
Fix ECDSA test_sign that would fail verifying the signature when using pre_hashed option

### DIFF
--- a/crypto_condor/primitives/ECDSA.py
+++ b/crypto_condor/primitives/ECDSA.py
@@ -851,11 +851,13 @@ def _test_sign_nist(
             logger.debug("Test vector error", exc_info=True)
             continue
 
-        message = bytes.fromhex(test.message)
+        raw_message = bytes.fromhex(test.message)
         if pre_hashed:
             digest = hashes.Hash(hash_function.get_hash_instance())
-            digest.update(message)
+            digest.update(raw_message)
             message = digest.finalize()
+        else:
+            message = raw_message
 
         try:
             signature = sign_function(key, message)
@@ -884,7 +886,7 @@ def _test_sign_nist(
         )
 
         data = SigData(info, key, message, signature)
-        if _verify(serialized_pub_key, hash_function, message, signature):
+        if _verify(serialized_pub_key, hash_function, raw_message, signature):
             info.result = True
         else:
             info.error_msg = "Signature is not valid"

--- a/crypto_condor/primitives/ECDSA.py
+++ b/crypto_condor/primitives/ECDSA.py
@@ -108,6 +108,10 @@ class Sign(Protocol):
             private_key: The private elliptic curve key. Either PEM-encoded,
                 DER-encoded, or as serialized int.
             message: The message to sign.
+
+            
+        Returns:
+            The signed message.
         """
         ...  # pragma: no cover (protocol)
 


### PR DESCRIPTION
Hi :wave: 

When using the `pre_hashed` option on `ECDSA.test_sign`, the message replaced by its hash. But following the call to the sign harness, the results are then given to crypto-condor `_verify` function. However, the message now contains the hash of the message which will make the call to `_verify` to return that the signature is invalid in every case.
This PR fixes this issue by keeping the complete message even when the `pre_hashed` option is enabled.

I've also added the missing return value in the documentation for the [ECDSA sign protocol](https://quarkslab.github.io/crypto-condor/latest/python-api/primitives/ECDSA.html#crypto_condor.primitives.ECDSA.Sign).

Let me know if you want me to fix it differently or add anything to this.