### PR TITLE
Fix `--[no-]compliance` and `--[no-]resilience` being ignored in ECDH, HMAC, SHAKE harnesses

### DIFF
--- a/crypto_condor/primitives/ECDH.py
+++ b/crypto_condor/primitives/ECDH.py
@@ -1021,7 +1021,7 @@ def test_lib(
                     )
                     continue
                 rd |= _test_harness_exchange_point(
-                    ffi, lib, function, curve, True, True
+                    ffi, lib, function, curve, compliance, resilience
                 )
             case ["CC", "ECDH", "exchange", "x509", _curve]:
                 try:
@@ -1031,7 +1031,9 @@ def test_lib(
                         "Invalid curve %s for ECDH, skipped %s", _curve, function
                     )
                     continue
-                rd |= _test_harness_exchange_x509(ffi, lib, function, curve, True, True)
+                rd |= _test_harness_exchange_x509(
+                    ffi, lib, function, curve, compliance, resilience
+                )
             case ["CC", "ECDH", *_]:
                 logger.warning("Invalid CC_ECDH function %s, skipped", function)
                 continue

--- a/crypto_condor/primitives/HMAC.py
+++ b/crypto_condor/primitives/HMAC.py
@@ -1113,7 +1113,9 @@ def test_wrapper(wrapper: Path, compliance: bool, resilience: bool) -> ResultsDi
 # --------------------------- Harness -------------------------------------------------
 
 
-def _test_harness_digest(ffi: cffi.FFI, lib, function: str, algo: Hash) -> ResultsDict:
+def _test_harness_digest(
+    ffi: cffi.FFI, lib, function: str, algo: Hash, compliance: bool, resilience: bool
+) -> ResultsDict:
     """Tests a harness for digest."""
     logger.info("Testing harness function %s", function)
 
@@ -1137,10 +1139,12 @@ def _test_harness_digest(ffi: cffi.FFI, lib, function: str, algo: Hash) -> Resul
             raise ValueError(f"{function} failed with code {rc}")
         return bytes(c_mac)
 
-    return test_digest(_digest, algo)
+    return test_digest(_digest, algo, compliance=compliance, resilience=resilience)
 
 
-def _test_harness_verify(ffi: cffi.FFI, lib, function: str, algo: Hash) -> ResultsDict:
+def _test_harness_verify(
+    ffi: cffi.FFI, lib, function: str, algo: Hash, compliance: bool, resilience: bool
+) -> ResultsDict:
     """Tests a harness for verify."""
     logger.info("Testing harness function %s", function)
 
@@ -1167,7 +1171,7 @@ def _test_harness_verify(ffi: cffi.FFI, lib, function: str, algo: Hash) -> Resul
         else:
             raise ValueError(f"{function} failed with code {rc}")
 
-    return test_verify(_verify, algo)
+    return test_verify(_verify, algo, compliance=compliance, resilience=resilience)
 
 
 def test_lib(
@@ -1199,14 +1203,14 @@ def test_lib(
                 except ValueError as error:
                     logger.error(str(error))
                     continue
-                rd |= _test_harness_digest(ffi, lib, func, algo)
+                rd |= _test_harness_digest(ffi, lib, func, algo, compliance, resilience)
             case ["CC", "HMAC", "verify", *parts]:
                 try:
                     algo = Hash.from_funcname(parts)
                 except ValueError as error:
                     logger.error(str(error))
                     continue
-                rd |= _test_harness_verify(ffi, lib, func, algo)
+                rd |= _test_harness_verify(ffi, lib, func, algo, compliance, resilience)
             case _:
                 logger.debug("Skipped invalid CC_HMAC function %s", func)
                 continue

--- a/crypto_condor/primitives/SHAKE.py
+++ b/crypto_condor/primitives/SHAKE.py
@@ -450,7 +450,13 @@ def run_python_wrapper(wrapper: Path, compliance: bool, resilience: bool):
 
 
 def _test_lib_digest(
-    ffi: cffi.FFI, lib, function: str, algorithm: Algorithm, orientation: Orientation
+    ffi: cffi.FFI,
+    lib,
+    function: str,
+    algorithm: Algorithm,
+    orientation: Orientation,
+    compliance: bool,
+    resilience: bool,
 ) -> ResultsDict:
     """Tests a harness digest.
 
@@ -473,7 +479,9 @@ def _test_lib_digest(
             raise ValueError(f"{function} returned {retval}")
         return bytes(buf)
 
-    return test_digest(_shake, algorithm, orientation)
+    return test_digest(
+        _shake, algorithm, orientation, compliance=compliance, resilience=resilience
+    )
 
 
 def test_lib(
@@ -521,6 +529,8 @@ def test_lib(
                 orientation = Orientation.BIT
             case _:
                 logger.debug("Ignoring unknown CC_SHAKE function %s", function)
-        rd |= _test_lib_digest(ffi, lib, function, algorithm, orientation)
+        rd |= _test_lib_digest(
+            ffi, lib, function, algorithm, orientation, compliance, resilience
+        )
 
     return rd


### PR DESCRIPTION
In the primitives addressed by this PR, the `--[no-]compliance` and `--[no-]resilience` flags in the harness CLI are completely ignored. HMAC and SHAKE always operate in `--compliance --no-resilience` mode, and ECDH always operates in `--compliance --resilience` mode. This PR fixes that.

Only private functions suffered signature modifications, so this does not seem like a breaking change besides the fix itself.

I have tested the 5/10 primitives with ready-to-use examples on [the Harness API doc](https://quarkslab.github.io/crypto-condor/latest/harness-api/index.html) regarding this issue ; AES and SHA appear OK. I'm also aware of the issue being in SLH-DSA. The issue may be present as well in any of ChaCha20, HQC, ML-DSA, ML-KEM, I have not tested them so far.

Running `make all`, as many tests succeed/fail as before the changes.