### PR TITLE
Add support for random test vectors in SHA and HMAC functions

### DIFF
--- a/crypto_condor/cli/run.py
+++ b/crypto_condor/cli/run.py
@@ -68,8 +68,8 @@ _compliance = typer.Option(
 _resilience = typer.Option(
     "--resilience/--no-resilience", help="Use resilience test vectors."
 )
-_random_inputs = typer.Option(
-    "--random-inputs/--no-random-inputs", help="Use random test vectors."
+_randomness = typer.Option(
+    "--randomness/--no-randomness", help="Use random test vectors."
 )
 _encrypt = typer.Option("--encrypt/--no-encrypt", help="Test the encryption function.")
 _decrypt = typer.Option("--decrypt/--no-decrypt", help="Test the decryption function.")
@@ -313,7 +313,7 @@ def sha(
     wrapper: Annotated[str, typer.Argument(metavar="FILE")],
     compliance: Annotated[bool, _compliance] = True,
     resilience: Annotated[bool, _resilience] = False,
-    random_inputs: Annotated[bool, _random_inputs] = False,
+    randomness: Annotated[bool, _randomness] = False,
     filename: Annotated[str, _filename] = "",
     no_save: Annotated[bool, _no_save] = False,
     debug: Annotated[Optional[bool], _debug] = None,
@@ -329,7 +329,7 @@ def sha(
             Whether to use compliance test vectors.
         resilience:
             Whether to use resilience test vectors.
-        random_inputs:
+        randomness:
             Whether to use random test vectors.
         filename:
             Name of the file to save results.
@@ -339,7 +339,7 @@ def sha(
             When saving the results to a file, whether to add the debug data.
     """
     try:
-        results = SHA.test_wrapper(Path(wrapper), compliance, resilience, random_inputs)
+        results = SHA.test_wrapper(Path(wrapper), compliance, resilience, randomness)
     except ValueError as error:
         logger.error(error)
         raise typer.Exit(1) from error
@@ -582,6 +582,7 @@ def hmac(
     wrapper: Annotated[str, typer.Argument(metavar="FILE")],
     compliance: Annotated[bool, _compliance] = True,
     resilience: Annotated[bool, _resilience] = False,
+    randomness: Annotated[bool, _randomness] = False,
     filename: Annotated[str, _filename] = "",
     no_save: Annotated[bool, _no_save] = False,
     debug: Annotated[Optional[bool], _debug] = None,
@@ -590,7 +591,7 @@ def hmac(
     from crypto_condor.primitives import HMAC
 
     try:
-        rd = HMAC.test_wrapper(Path(wrapper), compliance, resilience)
+        rd = HMAC.test_wrapper(Path(wrapper), compliance, resilience, randomness)
     except (FileNotFoundError, ValueError) as error:
         console.print(str(error))
         raise typer.Exit(1) from error

--- a/crypto_condor/cli/run.py
+++ b/crypto_condor/cli/run.py
@@ -68,6 +68,9 @@ _compliance = typer.Option(
 _resilience = typer.Option(
     "--resilience/--no-resilience", help="Use resilience test vectors."
 )
+_random_inputs = typer.Option(
+    "--random-inputs/--no-random-inputs", help="Use random test vectors."
+)
 _encrypt = typer.Option("--encrypt/--no-encrypt", help="Test the encryption function.")
 _decrypt = typer.Option("--decrypt/--no-decrypt", help="Test the decryption function.")
 _sign = typer.Option("--sign/--no-sign", help="Test the signing function.")
@@ -310,6 +313,7 @@ def sha(
     wrapper: Annotated[str, typer.Argument(metavar="FILE")],
     compliance: Annotated[bool, _compliance] = True,
     resilience: Annotated[bool, _resilience] = False,
+    random_inputs: Annotated[bool, _random_inputs] = False,
     filename: Annotated[str, _filename] = "",
     no_save: Annotated[bool, _no_save] = False,
     debug: Annotated[Optional[bool], _debug] = None,
@@ -325,6 +329,8 @@ def sha(
             Whether to use compliance test vectors.
         resilience:
             Whether to use resilience test vectors.
+        random_inputs:
+            Whether to use random test vectors.
         filename:
             Name of the file to save results.
         no_save:
@@ -333,7 +339,7 @@ def sha(
             When saving the results to a file, whether to add the debug data.
     """
     try:
-        results = SHA.test_wrapper(Path(wrapper), compliance, resilience)
+        results = SHA.test_wrapper(Path(wrapper), compliance, resilience, random_inputs)
     except ValueError as error:
         logger.error(error)
         raise typer.Exit(1) from error

--- a/crypto_condor/primitives/SHA.py
+++ b/crypto_condor/primitives/SHA.py
@@ -479,9 +479,13 @@ def test_digest(
             res.add(info)
 
     if random_inputs:
-        last_id = vectors.tests[-1].id if vectors.tests else 0
-        # consider also the monte-carlo test
-        last_id += 1
+        last_id = (
+            max(
+            (test.id for vectors in all_vectors for test in vectors.tests),
+            default=0,
+            )
+            + 1
+        )
         # 10 random values are enough to detect incorrect implementations
         random_vectors = _generate_random_vectors(algorithm, 10, last_id + 1)
 

--- a/crypto_condor/primitives/SHA.py
+++ b/crypto_condor/primitives/SHA.py
@@ -260,6 +260,7 @@ def _generate_random_vectors(algo: Algorithm, n: int, start_id: int) -> ShaVecto
                 md=_sha(algo, msg),
             )
         )
+    
     return vectors
 
 

--- a/crypto_condor/primitives/SHA.py
+++ b/crypto_condor/primitives/SHA.py
@@ -313,7 +313,7 @@ def test_digest(
     *,
     compliance: bool = True,
     resilience: bool = False,
-    random_inputs: bool = False,
+    randomness: bool = False,
 ) -> ResultsDict:
     """Tests a SHA implementation.
 
@@ -331,7 +331,7 @@ def test_digest(
             Whether to use compliance test vectors.
         resilience:
             Whether to use resilience test vectors.
-        random_inputs:
+        randomness:
             Whether to use random input vectors.
 
     Returns:
@@ -478,7 +478,7 @@ def test_digest(
                 info.fail(f"Failed at checkpoint {j}", mc_data)
             res.add(info)
 
-    if random_inputs:
+    if randomness:
         last_id = (
             max(
             (test.id for vectors in all_vectors for test in vectors.tests),
@@ -489,7 +489,7 @@ def test_digest(
         # 10 random values are enough to detect incorrect implementations
         random_vectors = _generate_random_vectors(algorithm, 10, last_id + 1)
 
-        for test in track(random_vectors.tests, rf"\[{str(algorithm)}] Random tests"):
+        for test in track(random_vectors.tests, rf"\[{str(algorithm)}] Random vectors"):
             info = TestInfo.new_from_test(test, False)
             data = DigestData(test.msg, test.md)
             try:
@@ -517,7 +517,7 @@ def test_digest(
 
 
 def test_wrapper_python(
-    wrapper: Path, compliance: bool, resilience: bool, random_inputs: bool
+    wrapper: Path, compliance: bool, resilience: bool, randomness: bool
 ) -> ResultsDict:
     """Tests a Python SHA wrapper.
 
@@ -528,7 +528,7 @@ def test_wrapper_python(
             Whether to use compliance test vectors.
         resilience:
             Whether to use resilience test vectors.
-        random_inputs:
+        randomness:
             Whether to use random test vectors.
 
     .. versionadded:: 2025.03.12
@@ -561,7 +561,7 @@ def test_wrapper_python(
                     algo,
                     compliance=compliance,
                     resilience=resilience,
-                    random_inputs=random_inputs,
+                    randomness=randomness,
                 )
             case ["CC", "SHA", *_]:
                 logger.warning("Ignored unknown CC_SHA function %s", func)
@@ -573,7 +573,7 @@ def test_wrapper_python(
 
 
 def test_wrapper(
-    wrapper: Path, compliance: bool, resilience: bool, random_inputs: bool
+    wrapper: Path, compliance: bool, resilience: bool, randomness: bool
 ) -> ResultsDict:
     """Tests a SHA wrapper.
 
@@ -586,7 +586,7 @@ def test_wrapper(
             Whether to use compliance test vectors.
         resilience:
             Whether to use resilience test vectors.
-        random_inputs:
+        randomness:
             Whether to use random test vectors.
 
     Raises:
@@ -601,7 +601,7 @@ def test_wrapper(
 
     match wrapper.suffix:
         case ".py":
-            return test_wrapper_python(wrapper, compliance, resilience, random_inputs)
+            return test_wrapper_python(wrapper, compliance, resilience, randomness)
         case _:
             raise ValueError(f"No runner for '{wrapper.suffix}' wrappers")
 


### PR DESCRIPTION
This PR allows users to test SHA functions using random test vectors, in addition to the usual ones (NIST).

An implementation cannot be fully tested without providing it with unpredictable inputs (i.e., random inputs) and verifying that the output matches the expected result.

`make all` was run and completed without errors.