### PR TITLE
Update CONTRIBUTING.md to reference gnu libtool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ The external dependencies are (not including Python packages):
 - [poetry](https://python-poetry.org/).
 - GNU Make and gcc (or clang for MacOS).
 - [protoc](https://grpc.io/docs/protoc-installation/), the protobuf compiler.
+- [Gnu Libtool](https://www.gnu.org/software/libtool/) (`sudo apt install libtool`)
 
 To configure the Python dependencies and the repo:
 


### PR DESCRIPTION
This PR update the `CONTRIBUTING.md` file to reference GNU Libtool.

The script `crypto_condor/primitives/_testu01/bootstrap` uses libtool at the lines 15 and 17.  If GNU Libtool is not installed, the script `make init` will fail due to a missing dependency.